### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/SETaP-2025-2026-Group-7-Team-C/Dorm-Chores-Scheduler/security/code-scanning/1](https://github.com/SETaP-2025-2026-Group-7-Team-C/Dorm-Chores-Scheduler/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block to the workflow (either at the root level to cover all jobs, or inside each job) and set it to the minimal scope required. For a lint/typecheck CI job that just reads the repository contents and does not need to modify anything on GitHub, `contents: read` is typically sufficient. This both documents the intent and prevents the token from having unnecessary write access if repository or organization defaults are broad.

For this specific file `.github/workflows/ci.yml`, the single best change without altering existing behavior is to add a root-level `permissions` block immediately after the `name: CI` line. This will apply to all jobs (currently only `lint_typecheck`) that do not override permissions. The block should be:

```yaml
permissions:
  contents: read
```

This keeps the job fully functional (checkout and Node setup use the token only for read access) while constraining the `GITHUB_TOKEN` scope. No additional imports, methods, or definitions are needed, as this is purely a YAML configuration change inside the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
